### PR TITLE
Add grub 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Inspired by and based on [patriziobruno/grubreboot-gnome-shell-extension](https:
 | Bootloader   | Supported |
 | ------------ | --------- |
 | systemd-boot | Yes       |
-| GRUB         | Planned   |
+| GRUB         | Yes       |
 
 A gnome-shell extension to add a "Custom Restart..." option to the shell system panel that allows you to choose what OS you want to boot into, after which it triggers the typical end session dialog for restart.
 
@@ -25,7 +25,11 @@ When you select the operating system to reboot into, you'll be required to input
 
 ## GRUB
 
-Plan to use similar logic to that used by the original grubreboot-gnome-shell-extension.
+It's able to set the default menu entry using `grub-reboot title`
+
+The presented options are parsed from the grub config.
+
+When you select the operating system to reboot into, you'll be required to input your password because of required permissions to run `grub-reboot`.
 
 ## Caveats
 

--- a/extension.js
+++ b/extension.js
@@ -51,7 +51,7 @@ class Extension {
 
     enable() {
         Utils.setDebug(false);
-        this._bootLoaderType = 0;
+        this._bootLoaderType = Utils.getCurrentBootloaderType();
         this._currentBootLoader = Utils.getCurrentBootloader();
         this._currentBootLoader.getBootOptions().then(([bootOps, defaultOpt]) => {
             if(bootOps === undefined)
@@ -109,7 +109,9 @@ class Extension {
     }
 
     _destroySubMenu() {
-        this._bootOptionsSubMenu.destroy();
-        this._bootOptionsSubMenu = null;
+        if (this._bootOptionsSubMenu) {
+            this._bootOptionsSubMenu.destroy();
+            this._bootOptionsSubMenu = null;
+        }
     }
 }

--- a/grub.js
+++ b/grub.js
@@ -19,6 +19,83 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-function getBootOptions() {
-    return undefined;
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
+const Gio = imports.gi.Gio;
+const ByteArray = imports.byteArray;
+
+
+/**
+ * getBootOptions:
+ * @returns {[Map, String]} Map(title, title), defaultOption
+ * 
+ * Parses the grub config to get the currently configured
+ * menuentries.
+ * defaultOption is set to the first menuentry
+ */
+async function getBootOptions() {
+    try {
+        let cfgpath = Utils.getGrubConfig();
+        if (cfgpath == "") {
+            throw new String("Failed to find grub config");
+        }
+
+        let bootOptions = new Map();
+
+        let file = Gio.file_new_for_path(cfgpath);
+        let [suc, content] = file.load_contents(null);
+        if (!suc) {
+            throw new String("Failed to load grub config");
+        }
+
+        let lines;
+        if (content instanceof Uint8Array) {
+            lines = ByteArray.toString(content);
+        }
+        else {
+            lines = content.toString();
+        }
+
+        let entryRx = /^menuentry ['"]([^'"]+)/;
+        lines.split('\n').forEach(l => {
+            let res = entryRx.exec(l);
+            if (res && res.length) {
+                bootOptions.set(res[1], res[1])
+            }
+        });
+
+        bootOptions.forEach((v, k) => {
+            Utils._log(`${k} = ${v}`);
+        });
+
+        return [bootOptions, bootOptions.keys().next().value];
+            
+    } catch (e) {
+        Utils._logWarning(e);
+        return undefined;
+    }
+}
+
+/**
+ * setBootOption:
+ * 
+ * @param {string} title
+ * @returns {bool} whether it was able to set it or not
+ * 
+ * The menuentry title to be passed to grub-reboot so that that
+ * boot option is set to be the one to boot off of next boot. 
+ */
+ async function setBootOption(title) {
+    try {
+        let [status, stdout, stderr] = await Utils.execCommand(
+            ['/usr/bin/pkexec', '/usr/sbin/grub-reboot', title],
+        );
+        if (status !== 0)
+            throw new String(`Failed to set boot option to ${title}:\nExitCode: ${status}\nstdout: ${stdout}\nstderr: ${stderr}`);
+        Utils._log(`Set boot option to ${title}: ${status}\n${stdout}\n${stderr}`);
+        return true;
+    } catch (e) {
+        Utils._logWarning(e);
+        return false;
+    }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,9 @@
   "original-author": "DocQuantum (Daniel Shchur) <shchurgood@gmail.com>",
   "shell-version": [
     "3.36",
-    "3.38"
+    "3.38",
+    "40",
+    "41"
   ],
   "uuid": "customreboot@docquantum.github.io",
   "url": "https://github.com/docquantum/gnome-shell-extension-customreboot",

--- a/systemdBoot.js
+++ b/systemdBoot.js
@@ -41,7 +41,6 @@ async function getBootOptions() {
         Utils._log(`Failed to find bootctl binary`);
         return undefined;
     }
-    Utils._log(`bootcl found at ${bootctl}`);
 
     try {
         let [status, stdout, stderr] = await Utils.execCommand([bootctl, "list"]);

--- a/systemdBoot.js
+++ b/systemdBoot.js
@@ -36,8 +36,15 @@ const Utils = Me.imports.utils;
  * they will only show up on the next boot.
  */
 async function getBootOptions() {
+    let bootctl = Utils.getBootctlPath();
+    if (bootctl == "") {
+        Utils._log(`Failed to find bootctl binary`);
+        return undefined;
+    }
+    Utils._log(`bootcl found at ${bootctl}`);
+
     try {
-        let [status, stdout, stderr] = await Utils.execCommand(["/usr/sbin/bootctl", "list"]);
+        let [status, stdout, stderr] = await Utils.execCommand([bootctl, "list"]);
         if (status !== 0)
             throw new Error(`Failed to get list from bootctl: ${status}\n${stdout}\n${stderr}`) ;
         Utils._log(`bootctl list: ${status}\n${stdout}\n${stderr}`);

--- a/utils.js
+++ b/utils.js
@@ -63,6 +63,27 @@ function getBootctlPath() {
 }
 
 /**
+ * getGrubConfig
+ * @returns {string}
+ * 
+ * Returns the path of the grub config or an empty string if not exist
+ */
+function getGrubConfig() {
+    let pathes = ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"];
+
+    let file;
+
+    for (let i = 0; i < pathes.length; i++) {
+        file = Gio.file_new_for_path(pathes[i]);
+        if (file.query_exists(null)) {
+            return pathes[i];
+        }
+    }
+
+    return "";
+}
+
+/**
  * getCurrentBootloader:
  * @returns {string}
  * 
@@ -70,8 +91,26 @@ function getBootctlPath() {
  * and setting preferences.
  */
 function getCurrentBootloader() {
-    // Default to systemd-boot right now...
-    return BootLoaderClass[BootLoaderType.SYSTEMD_BOOT];
+    return BootLoaderClass[getCurrentBootloaderType()];
+}
+
+/**
+ * getCurrentBootloaderType:
+ * @returns {string}
+ * 
+ * Returns the current bootloader based on system configuration
+ * and setting preferences.
+ */
+ function getCurrentBootloaderType() {
+    // If there is a grub config, use grub-reboot, otherwise use systemdboot
+    
+    let grubcfg = getGrubConfig();
+
+    if (grubcfg != "") {
+        return BootLoaderType.GRUB;
+    }
+
+    return BootLoaderType.SYSTEMD_BOOT;
 }
 
 /**

--- a/utils.js
+++ b/utils.js
@@ -42,6 +42,27 @@ const BootLoaderClass = {
 };
 
 /**
+ * getBootctlPath
+ * @returns {string}
+ * 
+ * Returns the path of the bootctl binary or an empty string if not found
+ */
+function getBootctlPath() {
+    let pathes = ["/usr/sbin/bootctl", "/usr/bin/bootctl"];
+
+    let file;
+
+    for (let i = 0; i < pathes.length; i++) {
+        file = Gio.file_new_for_path(pathes[i]);
+        if (file.query_exists(null)) {
+            return pathes[i];
+        }
+    }
+    
+    return "";    
+}
+
+/**
  * getCurrentBootloader:
  * @returns {string}
  * 

--- a/utils.js
+++ b/utils.js
@@ -48,14 +48,14 @@ const BootLoaderClass = {
  * Returns the path of the bootctl binary or an empty string if not found
  */
 function getBootctlPath() {
-    let pathes = ["/usr/sbin/bootctl", "/usr/bin/bootctl"];
+    let paths = ["/usr/sbin/bootctl", "/usr/bin/bootctl"];
 
     let file;
 
-    for (let i = 0; i < pathes.length; i++) {
-        file = Gio.file_new_for_path(pathes[i]);
+    for (let i = 0; i < paths.length; i++) {
+        file = Gio.file_new_for_path(paths[i]);
         if (file.query_exists(null)) {
-            return pathes[i];
+            return paths[i];
         }
     }
     
@@ -69,14 +69,14 @@ function getBootctlPath() {
  * Returns the path of the grub config or an empty string if not exist
  */
 function getGrubConfig() {
-    let pathes = ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"];
+    let paths = ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"];
 
     let file;
 
-    for (let i = 0; i < pathes.length; i++) {
-        file = Gio.file_new_for_path(pathes[i]);
+    for (let i = 0; i < paths.length; i++) {
+        file = Gio.file_new_for_path(paths[i]);
         if (file.query_exists(null)) {
-            return pathes[i];
+            return paths[i];
         }
     }
 


### PR DESCRIPTION
Parses menuentries from grub config.
If there is a grub config in either /boot/grub/grub.cfg or /boot/grub2/grub.cfg, use the grub bootloader, otherwise use systemdboot.

There might be a better solution to distinguish the bootloader, eg. a configuration option.

This would fix #1

